### PR TITLE
better folder tags

### DIFF
--- a/f2flickr/uploadr.py
+++ b/f2flickr/uploadr.py
@@ -335,6 +335,11 @@ class Uploadr:
             realTags =  realTags.replace('_',' ')
             realTags =  realTags.replace('.',' ')
             realTags = realTags.strip()
+            
+            if configdict.get('full_folder_tags', 'false').startswith('true'):
+                realTags = os.path.dirname(folderTag).split(os.sep)
+                realTags = (' '.join('"' + item + '"' for item in  realTags))
+            
             picTags = '#' + folderTag.replace(' ','#') + ' ' + realTags
 
             if exiftags == {}:

--- a/uploadr.ini.sample
+++ b/uploadr.ini.sample
@@ -24,6 +24,14 @@ hidden = 2
 # e.g. Crete when folder is d:\testpictures\holidays\Crete\123img.jpg
 only_sub_sets  = false
 
+# set full_folder_tags to true if you wish to override the original (default) parsing 
+# of folder tags and instead treat each sub-folder name as a complete tag.
+# Example: 
+# /path to/my picture/
+# false (Default), tags are parsed: "path" "to" "my" "picture"
+# true, tags are parsed: "path to" "my picture"
+full_folder_tags = false
+
 #
 # Key and Hash codes. Use those established by the original folders2flicker author (default below)
 # or alternately request your own from Flickr.


### PR DESCRIPTION
This bugged me from the beginning... esp since my folders are descriptive multi-word folders.

I believe this change leaves the default functionality untouched -- just adds an option to handle folders better if desired.

It also leaves _ and . in folder name tags... that could be modified, but I assume if a user is uploading from organized folders, they have the names the way they want the for a reason.
