### PR TITLE
Updated URLs to match API documentation

### DIFF
--- a/f2flickr/flickr.py
+++ b/f2flickr/flickr.py
@@ -33,7 +33,7 @@ from xml.dom import minidom
 import hashlib
 import os
 
-HOST = 'http://flickr.com'
+HOST = 'https://flickr.com'
 API = '/services/rest'
 
 # set these here or using flickr.API_KEY in your application

--- a/f2flickr/uploadr.py
+++ b/f2flickr/uploadr.py
@@ -152,10 +152,10 @@ def buildRequest(theurl, fields, files):
     return urllib2.Request(theurl, body, txheaders)
 
 class APIConstants:
-    base = "http://flickr.com/services/"
+    base = "https://flickr.com/services/"
     rest   = base + "rest/"
     auth   = base + "auth/"
-    upload = base + "upload/"
+    upload = "https://up.flickr.com/services/upload/"
 
     token = "auth_token"
     secret = "secret"


### PR DESCRIPTION
Didn't work for me out of the box, I got the same error as issue #26. I had to change the URLs as in this patch.
