### PR TITLE
Fixed issue with missing 'delete' attribute on Photo class by reintro…

### DIFF
--- a/f2flickr/flickr.py
+++ b/f2flickr/flickr.py
@@ -187,7 +187,14 @@ class Photo(object):
         tags = uniq(tags)
         _dopost(method, auth=True, photo_id=self.id, tags=tags)
         self._load_properties()
+    
+    def delete(self):
+        """Delete photo from flickr
+        (flickr.photos.delete)
+        """
+        method = 'flickr.photos.delete'
 
+        _dopost(method, auth=True, photo_id=self.id)
 
     def addTags(self, tags):
         """Adds the list of tags to current tags. (flickr.photos.addtags)


### PR DESCRIPTION
This should fix the issue with missing delete attribute on the Photo class #46.  This shows when uploading a file that's changed and it needs to first be deleted from flickr. 