### PR TITLE
Add check for null sets.

### DIFF
--- a/f2flickr/tags2set.py
+++ b/f2flickr/tags2set.py
@@ -24,6 +24,10 @@ def _creatSet(photoSet, setName, existingSets):
         photos.append(flickr.Photo(id = photo))
 
     fset = None
+    # Ensure the desired set name isn't empty
+    if not setName:
+        return fset
+    
     unicodeSetName = setName.decode(sys.getfilesystemencoding())
     #check if set with the name exists already
     generate = 'Generating'


### PR DESCRIPTION
Prevent tags2set from attempting to create an empty set. Previously, it would
attempt to create a set based on the image's directory. If that directory were
the top-level directory (as specified in the ini), string sanitization would
remove the / and attempt to create an empty set ''. This would throw an error.

Now, if an empty set is detected, _creatSet simply returns.