### PR TITLE
Add option to prevent truncation of tags.

### DIFF
--- a/f2flickr/uploadr.py
+++ b/f2flickr/uploadr.py
@@ -414,7 +414,7 @@ class Uploadr:
             logging.debug("Getting EXIF for %s", image)
             f = open(image, 'rb')
             try:
-                exiftags = exifread.process_file(f)
+                exiftags = exifread.process_file(f, truncate_tags=(configdict.get('truncate_tags', 'true')!='false'))
             except MemoryError:
                 exiftags = {}
             f.close()

--- a/uploadr.ini.sample
+++ b/uploadr.ini.sample
@@ -47,6 +47,14 @@ full_folder_tags = false
 override_dates = 0
 
 #
+## set truncate_tags to false if you wish to override the original (default)
+## truncation of EXIF tag data. Originally, tags were truncated to 20 charaters,
+## but this can sometimes cause errors. Setting to false should fix this.
+## true (Default), tags are truncated
+## false, tags are not truncated
+truncate_tags = true
+
+#
 # Key and Hash codes. Use those established by the original folders2flicker author (default below)
 # or alternately request your own from Flickr.
 #


### PR DESCRIPTION
IMPORTANT: Do not merge until next release of ExifRead after 2.1.2. This
relies on a new option, truncate_tags, being passed to
exifread.process_file.

Add option to prevent EXIF tag data from being truncated. Currently,
exifread was truncating EXIF tag data to 20 characters and appending an
ellipsis, ... .  This ellipsis would then throw an error. To resolve
this, set the option truncate_tag=false (default true) in the ini file
to prevent this truncation and resolve the error.
