### PR TITLE
token dir option

### DIFF
--- a/f2flickr/uploadr.py
+++ b/f2flickr/uploadr.py
@@ -46,7 +46,20 @@ from xml.dom import minidom
 #
 # Location to scan for new images
 #
-IMAGE_DIR = configdict.get('imagedir')
+IMAGE_DIR = " ".join(sys.argv[1:])
+if IMAGE_DIR:
+  IMAGE_DIR = IMAGE_DIR
+else:
+  IMAGE_DIR = configdict.get('imagedir')  
+print "Using image dir: " + IMAGE_DIR
+  
+TOKEN_DIR = configdict.get('tokendir')
+if TOKEN_DIR:
+  print "Using token dir: " + TOKEN_DIR
+  os.chdir(TOKEN_DIR)
+else:
+  print "Using token dir: current directory" 
+
 #
 #   Flickr settings
 #

--- a/uploadr.ini.sample
+++ b/uploadr.ini.sample
@@ -3,7 +3,8 @@
 # Location to scan for new images (no trailing \)
 #
 # Example: imagedir = d:\pictures
-imagedir = 
+imagedir =
+tokendir =
 
 #
 # File we keep the history of uploaded images in.
@@ -20,13 +21,13 @@ family = 1
 # Hide from public searches (if not set, this is the default):
 hidden = 2
 
-# set this to true if name of the auto generated flickr sets should be only name of the last sub folder 
+# set this to true if name of the auto generated flickr sets should be only name of the last sub folder
 # e.g. Crete when folder is d:\testpictures\holidays\Crete\123img.jpg
 only_sub_sets  = false
 
-# set full_folder_tags to true if you wish to override the original (default) parsing 
+# set full_folder_tags to true if you wish to override the original (default) parsing
 # of folder tags and instead treat each sub-folder name as a complete tag.
-# Example: 
+# Example:
 # /path to/my picture/
 # false (Default), tags are parsed: "path" "to" "my" "picture"
 # true, tags are parsed: "path to" "my picture"


### PR DESCRIPTION
Hello, this PR may solve #28 .
1. If the executable is used with a folder parameter, it uploades that folder (instead of the current folder).
2. If tokendir option is specified in .ini file, the token remains the same and independent for any uploaded folder.
